### PR TITLE
[WIP] Add MYSQL_ROOT_USER key to env in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
       DB: db
+      MYSQL_ROOT_USER: root
       MYSQL_USER: root
       MYSQL_PASSWORD:
 


### PR DESCRIPTION
My Rubygems deploy is failing with the message

```
$ release-gem /app/data/stacks/shopify/atlas-engine/rubygems/deploys/2448702/atlas_engine.gemspec
pid: 239530
Running: git tag -m 'Version 0.1.0' v0.1.0
rake aborted!
KeyError: key not found: "MYSQL_ROOT_USER" (KeyError)
```

https://shipit.shopify.io/shopify/atlas-engine/rubygems/deploys/2448702