### PR TITLE
hardcode env variables for dummy app

### DIFF
--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -15,8 +15,8 @@ development: &development
   collation: utf8mb4_unicode_ci
   adapter: mysql2
   pool: 5
-  username: <%= ENV.fetch("MYSQL_ROOT_USER") %>
-  password: <%= ENV.fetch("MYSQL_PASSWORD") %>
+  username: root
+  password:
   host: 127.0.0.1
   database: db
 


### PR DESCRIPTION
My Rubygems deploy is failing with the message

```
KeyError: key not found: "MYSQL_ROOT_USER" (KeyError)
```

https://shipit.shopify.io/shopify/atlas-engine/rubygems/deploys/2448702

Attempting to hardcode for now to unblock